### PR TITLE
docs: add `@guidepup/playwright` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [artillery-engine-playwright](https://github.com/artilleryio/artillery/tree/main/packages/artillery-engine-playwright) - Load testing with Playwright.
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD testing with Playwright runner and CucumberJS.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
+- [@guidepup/playwright](https://github.com/guidepup/guidepup-playwright) - VoiceOver and NVDA screen reader driver integration for Playwright.
 
 ## Language Support
 
@@ -64,7 +65,6 @@
 - [playwright-ui5](https://github.com/detachhead/playwright-ui5) - Custom selector engine for sapui5.
 - [playwright-xpath](https://github.com/detachhead/playwright-xpath) - Custom selector engine for xpath 2 and 3.
 - [ZeroStep](https://github.com/zerostep-ai/zerostep) - AI actions and assertions for Playwright.
-
 
 ## Reporters
 


### PR DESCRIPTION
Hi all 👋 

I maintain the [`@guidepup/playwright`](https://github.com/guidepup/guidepup-playwright) package which allows users to automate VoiceOver and NVDA screen readers through Playwright.

It would be amazing to be able to add this integration to this repo - shout if have any queries! 😄 