### PR TITLE
Add echoed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 - [testomatio-reporter](https://github.com/testomatio/reporter) - Runs and sends test executions to the TCMS testomatio, Jira / Linear / Azure DevOps task management.
 - [currents-dev](https://currents.dev/) - A Cloud Dashboard to debug, troubleshoot and analyze parallel Playwright CI tests.
 - [qase](https://github.com/qase-tms/qase-javascript/tree/master/qase-playwright) - Playwright Qase Reporter, send test executions to [qase](https://qase.io/).
+- [echoed](https://github.com/mrasu/echoed) - Makes tests observable by visualizing OpenTelemetry data in HTML.
 
 ## Showcases
 


### PR DESCRIPTION
`Echoed` collects OpenTelemetry's data to visualize requests made from Playwright tests and makes it easy to investigate failing tests.

![](https://raw.githubusercontent.com/mrasu/echoed/main/docs/img/howEchoedWorks.png)