### PR TITLE
Add @appetize/playwright & appwright integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD testing with Playwright runner and CucumberJS.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
 - [@guidepup/playwright](https://github.com/guidepup/guidepup-playwright) - VoiceOver and NVDA screen reader driver integration for Playwright.
-- [@appetize/playwright](https://docs.appetize.io/testing) – Mobile tests for web or native apps on [Appetize](https://www.appetize.io)'s virtual devices using Playwright.
-- [appwright](https://www.npmjs.com/package/appwright) – Mobile tests using Appium with Playwright.
+- [@appetize/playwright](https://docs.appetize.io/testing) - Mobile tests for web or native apps on [Appetize](https://www.appetize.io)'s virtual devices using Playwright Test Runner.
+- [appwright](https://www.npmjs.com/package/appwright) - Mobile tests using Appium with Playwright Test Runner.
 
 ## Language Support
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD testing with Playwright runner and CucumberJS.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
 - [@guidepup/playwright](https://github.com/guidepup/guidepup-playwright) - VoiceOver and NVDA screen reader driver integration for Playwright.
+- [@appetize/playwright](https://docs.appetize.io/testing) – E2E test Android/iOS apps, web apps, or webpages on [Appetize](https://www.appetize.io)'s virtual devices using Playwright.
 
 ## Language Support
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD testing with Playwright runner and CucumberJS.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
 - [@guidepup/playwright](https://github.com/guidepup/guidepup-playwright) - VoiceOver and NVDA screen reader driver integration for Playwright.
-- [@appetize/playwright](https://docs.appetize.io/testing) – E2E test Android/iOS apps, web apps, or webpages on [Appetize](https://www.appetize.io)'s virtual devices using Playwright.
+- [@appetize/playwright](https://docs.appetize.io/testing) – Mobile tests for web or native apps on [Appetize](https://www.appetize.io)'s virtual devices using Playwright.
+- [appwright](https://www.npmjs.com/package/appwright) – Mobile tests using Appium with Playwright.
 
 ## Language Support
 


### PR DESCRIPTION
Hi @mxschmitt,

> This is a PR to add Appetize's Playwright integration to the Integrations section of README.

This integration allows users to test their mobile or web applications with Playwright on Appetize's Android emulators and iOS simulators.

Thank you and please let me know if you have any questions!