### PR TITLE
Add Happo to integrations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [@guidepup/Playwright](https://github.com/guidepup/guidepup-playwright) - VoiceOver and NVDA screen reader driver integration for Playwright.
 - [@appetize/Playwright](https://docs.appetize.io/testing) - Mobile tests for web or native apps on [Appetize](https://www.appetize.io)'s virtual devices using Playwright Test Runner.
 - [appwright](https://www.npmjs.com/package/appwright) - Mobile tests using Appium with Playwright Test Runner.
+- [Happo](https://docs.happo.io/docs/playwright) - Catch unexpected visual and accessibility changes and UI bugs.
 
 ## Language Support
 


### PR DESCRIPTION
Happo integrates with more than playwright, so I thought it might make sense to link to the Playwright integration docs here. Let me know if you'd prefer to link to a different location!