### PR TITLE
Add Playwright Autopilot to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 - [playwright-magic-steps](https://github.com/vitalets/playwright-magic-steps) - Auto-transform JavaScript comments into Playwright steps.
 - [playwright-network-cache](https://github.com/vitalets/playwright-network-cache) - Speed up Playwright tests by caching network requests on the filesystem.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
+- [Playwright Autopilot](https://github.com/kaizen-yutani/playwright-autopilot) - AI-powered test debugger that captures DOM snapshots, network requests, and console output for every action, then autonomously diagnoses and fixes failures. Claude Code plugin using MCP.
 
 ## Reporters
 


### PR DESCRIPTION
Adds [Playwright Autopilot](https://github.com/kaizen-yutani/playwright-autopilot) to the Utils section.

It's a Claude Code plugin that debugs and fixes Playwright E2E tests autonomously. It captures DOM snapshots, network requests, console output, and screenshots for every browser action during a test run, then uses that data to diagnose and fix failures.

Built on MCP (Model Context Protocol) with 32 tools for on-demand debugging.