### PR TITLE
Add Playwright Manual-to-Test Generator (open-source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [playwright-network-cache](https://github.com/vitalets/playwright-network-cache) - Speed up Playwright tests by caching network requests on the filesystem.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
+- [Playwright Manual-to-Test Generator](https://github.com/rmgoede/playwright-manual-to-test-generator) – Deterministic conversion of manual test steps into a single runnable Playwright TypeScript test.
 
 ## Reporters
 


### PR DESCRIPTION
Adds the Playwright Manual-to-Test Generator and points to the open-source implementation (MIT licensed):

https://github.com/rmgoede/playwright-manual-to-test-generator

Previously discussed in #77 (implementation was private at the time, now fully open source).