### PR TITLE
add Visura API to Showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [Elastic APM JS agent](https://github.com/elastic/apm-agent-rum-js) - Playwright is used to run benchmark tests across browsers.
 - [Blockstack](https://github.com/blockstack/ux) - Playwright is used to run cross-browser UI tests.
 - [xterm.js](https://github.com/xtermjs/xterm.js) - Playwright is used to run cross-browser integration tests.
+- [Visura API](https://github.com/zornade/visura-api) - REST API service automating Italian cadastral property lookups (visure catastali) via Playwright headless browser with SPID authentication.
 
 ## Guides
 - [Currents Blog](https://currents.dev/blog/playwright) - Playwright articles written by QA professionals.


### PR DESCRIPTION
## Add Visura API to Showcases

[Visura API](https://github.com/zornade/visura-api) is a REST API service that automates Italian cadastral property record extraction (*visure catastali*) from the Agenzia delle Entrate SISTER portal.

It uses **Playwright** for headless browser automation to handle the full SPID authentication flow and navigate the SISTER web portal programmatically.

### Why it fits this list

- Real-world production use of Playwright for complex multi-step browser automation
- Handles SPID (Italian national digital identity) login flow
- Demonstrates Playwright usage beyond testing: as a core runtime automation engine
- Built with Python + FastAPI + Playwright
