### PR TITLE
Add playwright-page-object to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [Moon](https://github.com/aerokube/moon) - Tools for executing Playwright tests in parallel in a Kubernetes cluster.
 - [@bgotink/playwright-coverage](https://github.com/bgotink/playwright-coverage) - Report coverage on Playwright tests using v8 coverage, without requiring any instrumentation.
 - [playwright-best-practices-skill](https://github.com/currents-dev/playwright-best-practices-skill) - AI Skill to make agents experts at writing, debugging and maintaining Playwright tests.
+- [playwright-page-object](https://www.npmjs.com/package/playwright-page-object) - Decorator-driven selector composition for Playwright POM. Compose typed selectors in plain classes and custom controls with incremental Page Object Model adoption.
 - [playwright-test-coverage](https://github.com/anishkny/playwright-test-coverage) - Plugin to collect code coverage from running Playwright tests.
 - [Playwright Test for VSCode](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) - Official Playwright test extension for VS Code.
 - [playwright-elements](https://danteukraine.github.io/playwright-elements) - Playwright test extension for creatation of reusable components with ability to add child elements, methods and call them in chain. Reduce amount of your code in page object, or even use elements without page object.


### PR DESCRIPTION
## Description

Adds [`playwright-page-object`](https://github.com/sergeyshmakov/playwright-page-object) to the Utils section.

### What is it?

`playwright-page-object` is a decorator-first TypeScript library that provides a structured and reusable
Page Object Model abstraction for Playwright. It helps developers reduce repetitive selector
logic, improve test readability, and scale Playwright test suites more cleanly.

- **npm:** https://www.npmjs.com/package/playwright-page-object
- **GitHub:** https://github.com/sergeyshmakov/playwright-page-object

### Why does it belong here?

- Directly extends Playwright's testing capabilities
- Focused on developer experience and test architecture
- Actively maintained with TypeScript support
- Solves a real pain point in large Playwright test suites

### Checklist

- [x] The entry follows the existing format: `- [name](url) - Description.`
- [x] The description is short, clear, and ends with a period
- [x] The entry is placed in the correct section
- [x] The entry is added in alphabetical order within its section
- [x] The link points to the correct NPM package
- [x] The package is related to Playwright
