### PR TITLE
Add skipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [playwright-network-cache](https://github.com/vitalets/playwright-network-cache) - Speed up Playwright tests by caching network requests on the filesystem.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
+- [skipper](https://github.com/get-skipper/skipper) - Real-time test execution control via Google Spreadsheet, enabling instant toggle without code changes.
 
 ## Reporters
 


### PR DESCRIPTION
Add [skipper](https://github.com/get-skipper/skipper) to the Utils section.

Skipper gives teams real-time control over test execution via a shared Google Spreadsheet — enabling instant enable/disable without code changes, PRs, or deployments. It supports Playwright among other testing frameworks.

- MIT license
- GitHub: https://github.com/get-skipper/skipper