### PR TITLE
Add aria-eyes — accessibility color claim verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 
 ## Utils
 
+- [aria-eyes](https://github.com/TonciZ/aria-eyes) - Verify that color words in aria-labels and alt text match actual CSS colors. Automated WCAG 1.4.1 and 1.1.1 testing.
 - [@bgotink/playwright-coverage](https://github.com/bgotink/playwright-coverage) - Report coverage on Playwright tests using v8 coverage, without requiring any instrumentation.
 - [BrowserClaw](https://github.com/idan-rubin/browserclaw) - AI browser automation via accessibility snapshots and ref targeting, built on Playwright.
 - [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) - ESLint plugin for your Playwright testing needs.


### PR DESCRIPTION
Adds aria-eyes to the Utils section. A Playwright plugin that verifies color words in aria-labels and alt text match the actual rendered CSS colors, automating WCAG 1.4.1 (Use of Color) and 1.1.1 (Non-text Content) checks.

- [GitHub repo](https://github.com/TonciZ/aria-eyes)
- [Live demo](https://tonciz.github.io/aria-eyes/)
- MIT licensed, TypeScript, framework-agnostic core + Playwright plugin