### PR TITLE
Add playwright-praman to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD testing with Playwright runner and CucumberJS.
 - [Playwright CRX](https://github.com/ruifigueira/playwright-crx) - Playwright codegen as a chrome extension. Available in [Chrome Web Store](https://chromewebstore.google.com/detail/playwright-crx/jambeljnbnfbkcpnoiaedcabbgmnnlcd).
 - [playwright-graphql](https://www.npmjs.com/package/playwright-graphql?activeTab=readme) - Generates a type‑safe GraphQL client and fixtures for Playwright API tests, with a CLI for schema/operation generation and optional coverage reporting.
+- [playwright-praman](https://github.com/mrkanitkar/playwright-praman) - SAP UI5 and Fiori test automation plugin with typed control proxies, CLI agents, and AI test generation.
 - [playwright-pytest](https://github.com/microsoft/playwright-pytest/) - Official Pytest plugin for using Playwright pages with fixtures.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
 


### PR DESCRIPTION
Adds [playwright-praman](https://github.com/mrkanitkar/playwright-praman) to the Integrations section.

Playwright plugin for SAP UI5 and Fiori test automation. Extends Playwright Test
via `test.extend()` with fixtures for UI5 control discovery, authentication, OData,
Fiori Elements, and FLP navigation. Includes 199 typed UI5 control interfaces and
a built-in CLI with 3 AI agent roles (Planner, Generator, Healer) that work with
the Playwright MCP server — the first Playwright plugin to ship CLI agent support.

- **npm**: [playwright-praman](https://www.npmjs.com/package/playwright-praman) — v1.2.0, 38 versions, Apache-2.0
- **Docs**: [praman.dev](https://praman.dev)
- **Playwright-first**: `import { test, expect } from 'playwright-praman'`
- **CLI**: `npx playwright-praman plan|generate|heal` — agent-driven test automation

Listed under Integrations (not Utils) because it provides SAP ecosystem integration
via Playwright fixtures — distinct from the selector-engine approach of playwright-ui5
in Utils.