### PR TITLE
Add QATools to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [playwright-ui5](https://github.com/detachhead/playwright-ui5) - Custom selector engine for sapui5.
 - [playwright-xpath](https://github.com/detachhead/playwright-xpath) - Custom selector engine for xpath 2 and 3.
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
+- [QATools](https://qatools.dev) - Free browser-based toolkit for Playwright engineers — cheat sheet, error decoder, selector guide, POM generator, config builder, Selenium converter and more. No sign-up required.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
 


### PR DESCRIPTION
## What

Adds [QATools](https://qatools.dev) to the Utils section, alphabetically between POMWright and TestingBot.

## About QATools

QATools is a free, browser-based toolkit built for Playwright engineers:

- **Cheat Sheet** — 37 copy-paste Playwright snippets
- **Error Decoder** — instant fix suggestions for Playwright errors  
- **Selector Guide** — best-practice locator reference with decision wizard
- **POM Generator** — generate typed Page Object classes from HTML
- **POM Framework Builder** — full POM framework with base classes, fixtures and barrel exports
- **Config Builder** — generate production-ready `playwright.config.ts`
- **Selenium → Playwright Converter** — migrate Java, Python or C# Selenium tests
- **Test Converter** — plain English → Playwright code
- **CI Config Generator** — ready-to-paste pipeline YAML for GitHub Actions, GitLab CI etc.
- Plus Test Data Generator, AI Test Case Generator, TestID Linter and more

No sign-up, no paywall, 100% free.