### PR TITLE
Add playwright-xray-advanced-reporter to Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - [playwright-slack-report](https://github.com/ryanrosello-og/playwright-slack-report) - Publish your Playwright test results to your favorite Slack channel(s).
 - [playwright-smart-reporter](https://www.npmjs.com/package/playwright-smart-reporter) - A feature-rich HTML reporter with stability grades, trend analytics, retry analysis, performance tracking, and optional AI-powered failure analysis.
 - [playwright-tesults-reporter](https://github.com/tesults/playwright-tesults-reporter) - A library for uploading test results to Tesults from Playwright.
+- [playwright-xray-advanced-reporter](https://github.com/julienmerconsulting/playwright-xray-advanced-reporter) - Advanced Xray Cloud reporter with automatic Test Execution creation, Test Plan linking via GraphQL, screenshot/trace/video uploads, and rich ADF descriptions.
 - [playwright-xray](https://github.com/inluxc/playwright-xray) - Playwright Xray Reporter, send test executions to Jira / Xray.
 - [qase](https://github.com/qase-tms/qase-javascript/tree/main/qase-playwright) - Playwright Qase Reporter, send test executions to [qase](https://qase.io).
 - [TestDino](https://testdino.com) - An AI Cloud platform for Playwright test analytics with instant failure debugging, flaky test detection, and ML categorization.


### PR DESCRIPTION
Adds `playwright-xray-advanced-reporter`, an Xray Cloud reporter with features
not covered by the existing `playwright-xray` entry:

- Automatic Test Execution creation in JIRA (no manual step)
- Test Plan linking via Xray GraphQL API
- Automatic screenshot/trace/video attachment upload
- Rich ADF descriptions with metrics (pass rate, duration, environments)
- Multi-Playwright-project support (parallel runs)

MIT licensed, TypeScript, published on npm.