### PR TITLE
Add LocoPilot to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) - ESLint plugin for your Playwright testing needs.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
+- [LocoPilot](https://github.com/bobfromarcher/LocoPilot) - Vision, browser, and desktop control for any local LLM via Playwright. 35 REST endpoints, zero cloud dependencies.
 - [Moon](https://github.com/aerokube/moon) - Tools for executing Playwright tests in parallel in a Kubernetes cluster.
 - [octomind.dev](https://octomind.dev) - Auto-generated, run & maintained with AI-assisted test case discovery.
 - [playwright-best-practices-skill](https://github.com/currents-dev/playwright-best-practices-skill) - AI Skill to make agents experts at writing, debugging and maintaining Playwright tests.


### PR DESCRIPTION
## Summary

Adds [LocoPilot](https://github.com/bobfromarcher/LocoPilot) to the Utils section.

LocoPilot uses Playwright for all 16 of its browser automation endpoints, providing vision, browser, and desktop control for any local LLM. It exposes 35 REST endpoints total (browser, desktop, vision), runs fully on localhost via Ollama with zero cloud dependencies, and is MIT-licensed.

Placed alphabetically between Heroshot and Moon, matching the existing list format.