### PR TITLE
Add camofox-browser to Utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
+- [camofox-browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser server for AI agents that bypasses bot detection, usable as a Playwright-compatible automation backend.
 
 ## Reporters
 


### PR DESCRIPTION
## Addition

[camofox-browser](https://github.com/jo-inc/camofox-browser) — Stealth headless browser server for AI agents that bypasses bot detection, usable as a Playwright-compatible automation backend.

### Why it should be included

- **3,000+ GitHub stars**, actively maintained
- Built on Camoufox (Firefox fork with C++ fingerprint spoofing) — bypasses Cloudflare, Akamai, and other anti-bot systems
- Provides a REST API for browser automation (navigation, screenshots, content extraction, structured data extraction)
- Useful for Playwright users who need to automate sites with aggressive bot detection that blocks standard browsers
- Complements the Playwright ecosystem by providing a stealth browser backend
- Used in production by [jo](https://askjo.ai) (AI assistant) and [Hermes Agent](https://github.com/nousresearch/hermes-agent) (OpenClaw's agent framework)