### PR TITLE
Add playwright-recorder-plus to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [playwright-network-cache](https://github.com/vitalets/playwright-network-cache) - Speed up Playwright tests by caching network requests on the filesystem.
 - [Playwright-performance](https://www.npmjs.com/package/playwright-performance) - Plugin for measuring and analyzing performance of tested flows using Playwright.
 - [playwright-python-language-injection](https://github.com/Mattwmaster58/playwright-python-language-injection) - Language injection definitions for CSS/JS syntax highlighting when using `python-playwright` in PyCharm.
+- [playwright-recorder-plus](https://github.com/MuTsunTsai/playwright-recorder-plus) - Higher-quality alternative to the built-in `recordVideo`, with H.264/VP9 output, pause/resume, crop, multi-page contexts, and inline audio scheduling.
 - [playwright-skill](https://github.com/testdino-hq/playwright-skill) - 70+ production-tested Playwright skills for coding agents covering best practices, POM patterns, CI/CD, and migration paths.
 - [playwright-test-coverage](https://github.com/anishkny/playwright-test-coverage) - Plugin to collect code coverage from running Playwright tests.
 - [Playwright Test for VSCode](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) - Official Playwright test extension for VS Code.


### PR DESCRIPTION
Adds [playwright-recorder-plus](https://github.com/MuTsunTsai/playwright-recorder-plus) to the Utils section.

It's a drop-in alternative to Playwright's built-in `recordVideo` that addresses the long-standing requests in #8683 / #12056 / #17217 / #31424 (configurable codec / bitrate / fps): wraps `page.screencast` (1.59+) with a configurable ffmpeg pipeline (H.264 default, VP9 / AV1 / etc. via `ffmpegArgs`), and adds pause/resume, crop, multi-page contexts, and inline audio scheduling for tutorial / demo recording use cases.

MIT-licensed, cross-browser (chromium / firefox / webkit smoke tests included).