### PR TITLE
fix: contributing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@
 
 ## Contribute
 
-Contributions welcome! Read the [contribution guidelines](https://github.com/mxschmitt/awesome-playwright/blob/master/CONTRIBUTING.md) first.
+Contributions welcome! Read the [contribution guidelines](https://github.com/mxschmitt/awesome-playwright/blob/main/CONTRIBUTING.md) first.


### PR DESCRIPTION
Contributing.md 404s on the main repo because of master->main rename.

<img width="1375" height="437" alt="Screenshot 2026-04-27 at 14 58 16" src="https://github.com/user-attachments/assets/f6cd811c-5470-41a0-84de-4e9e3dccae39" />
