### PR TITLE
Add @taprun/from-playwright to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 - [playwright-ui5](https://github.com/detachhead/playwright-ui5) - Custom selector engine for sapui5.
 - [playwright-xpath](https://github.com/detachhead/playwright-xpath) - Custom selector engine for xpath 2 and 3.
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
+- [@taprun/from-playwright](https://www.npmjs.com/package/@taprun/from-playwright) - Convert Playwright `.spec.ts` / `.test.ts` test scripts into deterministic `.tap.json` plans that replay in MCP hosts (Claude Code, Cursor) at zero LLM tokens.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
 


### PR DESCRIPTION
Adds [@taprun/from-playwright](https://www.npmjs.com/package/@taprun/from-playwright) to the `## Utils` section.

## What it is

A Playwright-to-MCP converter. It reads `.spec.ts` / `.test.ts` test files and emits deterministic `.tap.json` plans that replay in any MCP host (Claude Code, Cursor, Cline, etc.) without re-invoking an LLM at runtime.

## Why Utils (not Integrations)

It's a static converter, not a runtime integration with Playwright. It runs once over your test source to produce a different artifact (a `.tap.json` plan), much like other Utils entries (`playwright-magic-steps`, `playwright-cleanup`, `playwright-skill`).

## Distribution

- Source: https://github.com/LeonTing1010/tap (MIT)
- Package: https://www.npmjs.com/package/@taprun/from-playwright
- Format spec: https://www.npmjs.com/package/@taprun/spec
- Sister adapters: `@taprun/from-puppeteer`, `@taprun/from-stagehand`
- Docs: https://taprun.dev/spec/plan-v1/

## Conventions

- Inserted alphabetically between POMWright and TestingBot
- Format `- [name](link) - Description.` matches surrounding entries
- Direct npm link (no shortener / redirect)