### PR TITLE
Add webtest-orch (Utils)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
+- [webtest-orch](https://github.com/CreatmanCEO/webtest-orch) - Claude Code skill for image-budget-safe end-to-end testing: LLM-driven exploration generates *.spec.ts on first run, deterministic replay afterward, with axe-core integration, bug fingerprinting, and run-diff (new / regression / persisting / fixed).
 
 ## Reporters
 


### PR DESCRIPTION
[webtest-orch](https://github.com/CreatmanCEO/webtest-orch) is a Claude Code skill for end-to-end web-app testing that respects Claude's inline-image budget — every browser operation runs inside a Task subagent, so screenshots never leak into the parent chat context.

**Why it's distinct** from the existing AI/skill entries on the list (`playwright-best-practices-skill`, `playwright-skill`):
- Those are best-practice references / prompt collections.
- webtest-orch is a full orchestration layer: probe → bootstrap → Playwright MCP exploration → spec generation → `npx playwright test` replay → fingerprint + diff → report. The image-budget invariant is the architectural anchor that makes long-running test sessions feasible.

**One-line install:** `npx webtest-orch@beta install`

**Validated end-to-end** on two production apps (Next.js portfolio + Supabase/FastAPI/WebSocket SaaS).

**Stack:** Playwright MCP + Playwright CLI + @axe-core/playwright + chrome-devtools-mcp.

License: MIT.

Added in alphabetical position under **Utils** (after "Try Playwright").