### PR TITLE
Add playwright-cli-sessions to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [octomind.dev](https://octomind.dev) - Auto-generated, run & maintained with AI-assisted test case discovery.
 - [playwright-best-practices-skill](https://github.com/currents-dev/playwright-best-practices-skill) - AI Skill to make agents experts at writing, debugging and maintaining Playwright tests.
 - [Playwright-cleanup](https://www.npmjs.com/package/playwright-cleanup) - A Playwright cleanup tool that simplifies test cleanup by undoing any changes to the testing environment.
+- [playwright-cli-sessions](https://github.com/gabrielantonyxaviour/playwright-cli-sessions) - Stateless shell CLI on top of Playwright with one optional persistent Chrome that all commands attach to via CDP. Saved logins as parallel-safe JSON, agent-aware failure semantics (next-steps blocks on every error, blind-retry-loop detector, dedicated browser-control-lost error class).
 - [playwright-elements](https://danteukraine.github.io/playwright-elements) - Playwright test extension for creation of reusable, chainable component elements to reduce page object boilerplate.
 - [playwright-magic-steps](https://github.com/vitalets/playwright-magic-steps) - Auto-transform JavaScript comments into Playwright steps.
 - [playwright-network-cache](https://github.com/vitalets/playwright-network-cache) - Speed up Playwright tests by caching network requests on the filesystem.


### PR DESCRIPTION
Adding `playwright-cli-sessions` to the Utils section.

It's a stateless shell CLI on top of Playwright with one optional persistent Chrome that all commands attach to via CDP. The angle that's a little different from existing entries:

- **Stateless per-command, persistent browser** — every CLI invocation is its own process; one optional `browser start` keeps a Chrome alive that all subsequent commands attach to. No long-lived server, no MCP stdio bottleneck, real shell `&` parallelism.
- **Saved logins as JSON files** under `~/.playwright-sessions/`. N parallel processes can share the same saved auth without coordination.
- **Agent-aware failure semantics** (v0.10.0+) — every error prints a `next steps:` block, the CLI watches its own usage log and warns on blind-retry loops, and tab/browser-control loss has a dedicated error class. Designed specifically for the way AI coding agents use Playwright.

- Repo: https://github.com/gabrielantonyxaviour/playwright-cli-sessions
- npm: https://www.npmjs.com/package/playwright-cli-sessions
- License: MIT
- CI green, full scenario test suite

Inserted alphabetically in Utils between `Playwright-cleanup` and `playwright-elements`. Happy to adjust the description or placement if it fits a different section better.