### PR TITLE
Add Human Browser to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) - ESLint plugin for your Playwright testing needs.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
-- [Human Browser](https://humanbrowser.cloud) - Stealth Playwright browser with residential proxy. Bypasses Cloudflare/DataDome/PerimeterX. iPhone 15 Pro fingerprint. Free trial.
+- [Human Browser](https://humanbrowser.cloud) - Playwright drop-in (`launchHuman()`) that runs your scripts on cloud browsers with residential IPs and real device fingerprints, exposed through one A2A + MCP API.
 - [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, and generate automation scripts.
 - [Moon](https://github.com/aerokube/moon) - Tools for executing Playwright tests in parallel in a Kubernetes cluster.
 - [octomind.dev](https://octomind.dev) - Auto-generated, run & maintained with AI-assisted test case discovery.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) - ESLint plugin for your Playwright testing needs.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
+- [Human Browser](https://humanbrowser.cloud) - Stealth Playwright browser with residential proxy. Bypasses Cloudflare/DataDome/PerimeterX. iPhone 15 Pro fingerprint. Free trial.
 - [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, and generate automation scripts.
 - [Moon](https://github.com/aerokube/moon) - Tools for executing Playwright tests in parallel in a Kubernetes cluster.
 - [octomind.dev](https://octomind.dev) - Auto-generated, run & maintained with AI-assisted test case discovery.


### PR DESCRIPTION
[Human Browser](https://humanbrowser.cloud) is a Playwright drop-in for AI agents and scraping pipelines. A single `launchHuman()` call runs your existing Playwright scripts on managed cloud browsers with residential IPs and real device fingerprints, and it also exposes an A2A + MCP endpoint so agents can drive the browser directly.

**Why it fits Utils:** like [TestingBot](https://testingbot.com) (cloud browsers for Playwright) and [BrowserClaw](https://github.com/idan-rubin/browserclaw) (AI browser automation built on Playwright), it's a tool built around Playwright rather than a test runner.

- Playwright-compatible API — `launchHuman()` drop-in
- Managed cloud browsers, residential IPs in 10+ countries
- Real, internally-consistent device fingerprints
- A2A + MCP endpoint for agent integration
- Open source: https://github.com/VirixLabs/humanbrowser · npm `@virixlabs/humanbrowser`
