### PR TITLE
Add BrowserTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 
 - [@bgotink/playwright-coverage](https://github.com/bgotink/playwright-coverage) - Report coverage on Playwright tests using v8 coverage, without requiring any instrumentation.
 - [BrowserClaw](https://github.com/idan-rubin/browserclaw) - AI browser automation via accessibility snapshots and ref targeting, built on Playwright.
+- [BrowserTrace](https://github.com/aaronlab/browsertrace) - Local trace viewer for Playwright + LLM browser-agent runs with screenshots, URLs, model I/O, errors, and shareable HTML exports.
 - [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) - ESLint plugin for your Playwright testing needs.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.


### PR DESCRIPTION
Adds BrowserTrace to the utilities list.

BrowserTrace is a local trace viewer for Playwright scripts where an LLM or browser agent is part of the control loop. It records screenshots, URLs, actions, model input/output, errors, and shareable HTML exports so failed Playwright + LLM runs are easier to debug.

Notes:

- Added one entry only
- Kept the existing list format
- Framed it specifically as Playwright + LLM/browser-agent debugging, not as a replacement for Playwright Trace Viewer

I also ran the repo's `npx -y awesome-lint README.md` command locally; it failed on an environment-level `Awesome list must reside in a valid git repository` message rather than this entry, so I expect the GitHub CI context to be the meaningful check.