### PR TITLE
Add qa-skills to Utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
+- - [qa-skills](https://github.com/petrkindlmann/qa-skills) – 42 QA and test-automation skills for AI coding agents. Playwright-first, includes playwright-automation, visual-testing, performance-testing, and AI-augmented test generation skills. Works with Claude Code, Codex, Cursor, and any Agent Skills Standard runtime.
 
 ## Reporters
 


### PR DESCRIPTION
## Adding qa-skills

Adds qa-skills to the Utils section — 42 QA and test-automation skills for AI coding agents. Playwright-first, includes playwright-automation, visual-testing, performance-testing, and AI-augmented test generation skills. Compatible with Claude Code, Codex, Cursor, and any Agent Skills Standard runtime. MIT licensed.

Repo: https://github.com/petrkindlmann/qa-skills
Install: npx skills add petrkindlmann/qa-skills