### PR TITLE
Add invisible-playwright to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) - ESLint plugin for your Playwright testing needs.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
+- [invisible-playwright](https://github.com/feder-cr/invisible_playwright) - Playwright wrapper for a stealth-patched Firefox 150 build. Drop-in replacement returning native Playwright Browser objects.
 - [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, and generate automation scripts.
 - [Moon](https://github.com/aerokube/moon) - Tools for executing Playwright tests in parallel in a Kubernetes cluster.
 - [octomind.dev](https://octomind.dev) - Auto-generated, run & maintained with AI-assisted test case discovery.


### PR DESCRIPTION
A Playwright drop-in that returns a native `playwright.sync_api.Browser` / `async_api.Browser` from a stealth-patched Firefox 150. Two-line migration from vanilla Playwright. The browser passes reCAPTCHA v3 / FingerprintPro / CreepJS without JS-level overrides since the spoofing is in the C++ source.

Repo: https://github.com/feder-cr/invisible_playwright