### PR TITLE
Add WrightTest — self-hosted Playwright test automation platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
+- [WrightTest](https://wrighttest.com) - Self-hosted low-code UI test automation platform. Record tests via noVNC live browser, run them headlessly with Playwright, schedule with cron and export as native `.spec.ts` files.
 
 ## Reporters
 


### PR DESCRIPTION
WrightTest is a self-hosted platform that wraps Playwright in a web UI.
It provides a visual recorder via noVNC, headless test runner, cron scheduler and export to native .spec.ts files.

GitHub: https://github.com/AlexFilippov-it/wrighttest
Site: https://wrighttest.com