### PR TITLE
Add SnapAPI to Showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 - [Elastic APM JS agent](https://github.com/elastic/apm-agent-rum-js) - Playwright is used to run benchmark tests across browsers.
 - [playwright-examples](https://github.com/microsoft/playwright-examples) - Various testing scenarios with Playwright.
 - [TypeScript](https://github.com/microsoft/TypeScript) - Playwright is used to test TypeScript.js across browsers.
+- [SnapAPI](https://snap.michaelcli.com) - REST API for website screenshots, metadata extraction, and PDF generation, powered by Playwright. [Source](https://github.com/myastroapp/snapapi-client).
 - [VS Code](https://github.com/microsoft/vscode) - Playwright is used to run cross-browser tests on their web builds.
 - [xterm.js](https://github.com/xtermjs/xterm.js) - Playwright is used to run cross-browser integration tests.
 


### PR DESCRIPTION
Adds [SnapAPI](https://snap.michaelcli.com) to the Showcases section.

SnapAPI is a production REST API for website screenshots, metadata extraction, and PDF generation, powered by Playwright for browser automation. It demonstrates Playwright used as the rendering engine for a public API service.

- Website: https://snap.michaelcli.com
- Source: https://github.com/myastroapp/snapapi-client
- API docs: https://snap.michaelcli.com/docs.html