### PR TITLE
add invisible_playwright (stealth Firefox, drop-in Playwright replacement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) - ESLint plugin for your Playwright testing needs.
 - [@global-cache/Playwright](https://github.com/vitalets/global-cache) - A key-value cache for sharing data between parallel workers and test runs.
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
+- [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - Drop-in Playwright replacement that ships a patched Firefox 150 binary with C++ source-level fingerprint patches. Passes reCAPTCHA v3 (0.90), FingerprintJS Pro, CreepJS without JS shims.
 - [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, and generate automation scripts.
 - [Moon](https://github.com/aerokube/moon) - Tools for executing Playwright tests in parallel in a Kubernetes cluster.
 - [octomind.dev](https://octomind.dev) - Auto-generated, run & maintained with AI-assisted test case discovery.


### PR DESCRIPTION
Adds invisible_playwright to the Utils section, alphabetically between Heroshot and Libretto.

What it is: a drop-in Playwright replacement that ships a patched Firefox 150 binary with C++ source-level fingerprint patches (canvas, WebGL, audio, fonts, WebRTC, navigator, timezone, SOCKS5 auth, DevTools). Existing Playwright Python scripts work after a 2-line change: replace `sync_playwright()` with `InvisiblePlaywright()`.

Why I think it fits the list: it is purely Playwright-compatible (same API surface, sync + async, all methods), so it slots into projects using awesome-playwright tools without changes. The only difference is the browser binary it talks to.

Measured detection results on Windows 10: 0.90 reCAPTCHA v3 score, 0 CreepJS lies, FingerprintJS Pro all flags negative.

MIT licensed. ~1k stars.