### PR TITLE
Add @vijaypjavvadi/bdd2pw, sel2pw, pw-emit — Selenium/BDD → Playwright migration tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [playwright-graphql](https://www.npmjs.com/package/playwright-graphql?activeTab=readme) - Generates a type‑safe GraphQL client and fixtures for Playwright API tests, with a CLI for schema/operation generation and optional coverage reporting.
 - [playwright-pytest](https://github.com/microsoft/playwright-pytest/) - Official Pytest plugin for using Playwright pages with fixtures.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
+- [@vijaypjavvadi/bdd2pw](https://www.npmjs.com/package/@vijaypjavvadi/bdd2pw) - Scaffold runnable Playwright TypeScript tests from Gherkin .feature files. Auto-detects existing Page Objects, scans live pages via Microsoft Playwright MCP, emits POMs and specs ready for execution. CLI + HTTP service.
 
 ## Language Support
 
@@ -69,6 +70,8 @@
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
+- [@vijaypjavvadi/pw-emit](https://www.npmjs.com/package/@vijaypjavvadi/pw-emit) - Playwright TypeScript emitter library that renders Page Objects, spec files, and project scaffolds from a generic intermediate representation. Powers sel2pw and bdd2pw.
+- [@vijaypjavvadi/sel2pw](https://www.npmjs.com/package/@vijaypjavvadi/sel2pw) - Convert Java + Selenium + TestNG test suites to Playwright TypeScript via rule-based AST traversal. Supports Selenium Java, C# NUnit, Cucumber BDD, SpecFlow with optional LLM fallback (Anthropic / OpenAI / Gemini).
 
 ## Reporters
 


### PR DESCRIPTION
Hi @mxschmitt, this PR adds three related npm packages I maintain for migrating Selenium and Cucumber BDD test suites to Playwright TypeScript.

## What I'm proposing

**Integrations**
- `@vijaypjavvadi/bdd2pw` — Gherkin → Playwright TypeScript scaffolder. Same category as the existing `playwright-bdd` and `cucumber-playwright` entries.

**Utils**
- `@vijaypjavvadi/sel2pw` — Selenium-to-Playwright AST-driven test converter.
- `@vijaypjavvadi/pw-emit` — Shared Playwright TypeScript emitter library that powers both packages above. Similar to `POMWright` (also in Utils).

## Why include

These three packages cover the migration story for teams moving from Selenium/Cucumber BDD test suites to Playwright — a common ask that isn't currently represented in the list.

- Active maintenance (all three published within the last 23 days, latest release a few hours ago)
- MIT-licensed
- Production-tested AST-based conversion (not LLM-first, with LLM as optional fallback)
- Alphabetical placement: each entry inserted in its section's alphabetical position by package name after `@`

## Checklist (per CONTRIBUTING.md)

- [x] Entries follow the existing format: `[name](link) - Description.`
- [x] Description ends with a period and is concise
- [x] Each entry placed in the most relevant section
- [x] Alphabetical order maintained within each section
- [x] No duplicates of existing entries

Happy to reorder, rename, or move entries between sections — let me know what fits the list's curation style best. Thanks for maintaining this!