### PR TITLE
Add xbrowser - browser automation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [Heroshot](https://github.com/omachala/heroshot) - Documentation screenshot automation. Visual picker to define screenshots, one command to regenerate them all.
 - [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, and generate automation scripts.
 - [Moon](https://github.com/aerokube/moon) - Tools for executing Playwright tests in parallel in a Kubernetes cluster.
+- [xbrowser](https://github.com/dyyz1993/xbrowser) - Browser automation CLI with 35+ commands (search, scrape, crawl, record/replay, 68 plugins). Complements Playwright for non-testing automation.
 - [octomind.dev](https://octomind.dev) - Auto-generated, run & maintained with AI-assisted test case discovery.
 - [playwright-best-practices-skill](https://github.com/currents-dev/playwright-best-practices-skill) - AI Skill to make agents experts at writing, debugging and maintaining Playwright tests.
 - [Playwright-cleanup](https://www.npmjs.com/package/playwright-cleanup) - A Playwright cleanup tool that simplifies test cleanup by undoing any changes to the testing environment.


### PR DESCRIPTION
## Add xbrowser

[xbrowser](https://github.com/dyyz1993/xbrowser) is a browser automation CLI that complements Playwright for non-testing use cases:

- **35+ CLI commands**: search, scrape, crawl, map, network, detect, etc.
- **68 built-in plugins**: Google, Bing, GitHub, Twitter, Reddit, etc.
- **Chain syntax**: `xbrowser "goto url && click btn && scrape"`
- **Record/Replay**: Record browser actions, replay headlessly
- **Anti-detection**: Built-in CDP fingerprint protection
- **MIT licensed**, `npm i -g @dyyz1993/xbrowser`

While Playwright excels at testing, xbrowser focuses on **doing things on the web** — scraping, SEO analysis, content automation, and AI agent workflows.

Docs: https://xbrowser.dev