### PR TITLE
Add Confidence Gate to Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 - [TestDino](https://testdino.com) - An AI Cloud platform for Playwright test analytics with instant failure debugging, flaky test detection, and ML categorization.
 - [testomatio-reporter](https://github.com/testomatio/reporter) - Runs and sends test executions to the TCMS testomatio, Jira / Linear / Azure DevOps task management.
 - [playwright-timeline-reporter](https://github.com/vitalets/playwright-timeline-reporter) - An interactive timeline reporter to optimize your test run performance and worker utilization.
+- [confidence-gate](https://github.com/OaktreeInnovations/confidence-gate) - Open-source AI verification layer that scores Playwright test runs 0–100, applies per-step vision AI verification, and issues a ship/watch/block gate decision. 
 
 ## Showcases
 


### PR DESCRIPTION
Adds Confidence Gate to the Reporters section.

Confidence Gate is an open-source tool that wraps Playwright test execution with an AI verification layer. Each step is verified against its screenshot using vision AI, scored for confidence (three states: passed/ inconclusive / failed), and the run gets a 0–100 score with a final gate decision: ship / watch / block.

MIT licensed. Self-hostable via Docker Compose.

https://github.com/OaktreeInnovations/confidence-gate