### PR TITLE
feat: add playwright-best-practices to Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 ## Guides
 
 - [Currents Blog](https://currents.dev/blog/playwright) - Playwright articles written by QA professionals.
+- [Playwright Best Practices](https://github.com/ZeeaanNawazHarall/playwright-best-practices) - Playwright TypeScript reference covering architecture, auth, CI/CD, and 13 anti-patterns, with three runnable example frameworks.
 - [Playwright Tips (videos)](https://www.youtube.com/playlist?list=PLMZDRUOi3a8NtMq3PUS5iJc2pee38rurc) - Video walkthroughs of common challenges testing and monitoring with Playwright.
 - [Playwright Weekly](https://playwrightweekly.com) - Curated aggregator of Playwright articles & news from the internet.
 - [playwrightsolutions.com](https://playwrightsolutions.com) - Curated Selection of Playwright Automated Test Problems and Solutions.


### PR DESCRIPTION
## Description

I'm adding [playwright-best-practices](https://github.com/ZeeaanNawazHarall/playwright-best-practices), a production-grade reference repository that covers:

- 10 documentation sections (architecture, fixtures, locators, authentication, CI/CD, flaky tests, accessibility, anti-patterns, etc.)
- Three runnable example frameworks (script-based, simple POM, split locator/action POM)
- An anti-pattern laboratory with isolated, labeled bad examples
- Self-demonstrating CI with post-test validation
- Full community health files (code of conduct, security policy, contributing guide)

All patterns are sourced from official Playwright docs or clearly labeled as architectural decisions, making the resource suitable for both beginners and large enterprise teams.

## Checklist

- [x] Only one link per pull request
- [x] The link is inserted in alphabetical order within its section (`Guides`)
- [x] The description is short (under 100 characters), factual, and non-promotional
- [x] I have read the [contribution guidelines](https://github.com/mxschmitt/awesome-playwright/blob/main/CONTRIBUTING.md)
- [x] The project is actively maintained (CI green, CHANGELOG present)