### PR TITLE
Add Scraping & Automation and AI & Agents sections

### DIFF
--- a/.claude/skills/review-prs/SKILL.md
+++ b/.claude/skills/review-prs/SKILL.md
@@ -10,7 +10,7 @@ You are helping an awesome-list maintainer review open pull requests. Most PRs o
 ## Phase 1: Research & Report
 
 ### Step 1: Gather context
-1. Read `.claude/REVIEW_REQUIREMENTS.md` for the full 10-point review criteria.
+1. Read `references/review-criteria.md` (in this skill's base directory) for the full 10-point review criteria.
 2. Read `README.md` to understand existing entries, categories, and formatting conventions.
 3. Fetch all open PRs:
    ```bash
@@ -47,21 +47,32 @@ Evaluate each PR against the criteria from `references/review-criteria.md`. Key 
 - **Duplication**: Is something similar already listed? Only add if clearly better/different.
 - **Formatting**: Alphabetical order, one bullet per entry, correct naming, no tracking links.
 
-### Step 4: Generate review document
-Produce a document with:
+### Step 4: Generate the HTML review report
+Write a single self-contained HTML file to `pr-review-report.html` in the repo root (no external CSS/JS/CDN — inline everything so it opens offline). This is the primary deliverable the user reviews.
 
-1. **Per-PR details** including:
-   - PR number, title, author
-   - What it adds (one sentence)
-   - Project stats: stars, license, last activity
-   - Verdict: **MERGE**, **CLOSE**, or **REQUEST CHANGES**
-   - Reason (one sentence)
-   - For CLOSE: a draft closing comment that is friendly but not verbose
+The report MUST contain:
 
-2. **Summary table** at the end:
-   | PR | Title | Recommendation | Reason |
+1. **Header**: title, generation date, and counts (total PRs, # merge, # close, # request changes).
 
-3. Present to the user and explicitly ask for approval or overrides before proceeding to Phase 2.
+2. **A summary table** near the top with one row per PR. Columns:
+   `PR # | Title | Author | Target section | Stars | License | Last activity | Recommended action | Reason`
+   - Make the PR # a clickable link to the PR URL.
+   - Color-code the action cell so it's scannable: **MERGE** = green, **CLOSE** = red, **REQUEST CHANGES** = amber. Use an inline `style` or a CSS class with a colored badge.
+
+3. **Per-PR detail cards** (one per PR, below the table), each showing:
+   - PR number + title (linked), author
+   - What it adds (one factual sentence) and which section/line the diff targets
+   - Project stats: stars, license, created date, last activity, npm info if relevant
+   - Any red flags (scope, ethics/ToS, duplication, licensing, formatting)
+   - The recommended action as a colored badge, plus a one-sentence reason
+   - For **CLOSE**: include the draft friendly closing comment (in a `<blockquote>` or `<pre>`) so the user can review the exact wording before it's posted.
+
+Keep the verdicts to **MERGE**, **CLOSE**, or **REQUEST CHANGES**. Sort the cards by recommended action (merges first, then request-changes, then closes) so the actionable items are at the top.
+
+After writing the file, run `open pr-review-report.html` (macOS) so it opens in the browser, then tell the user the path. Also give a brief summary in chat (the counts and any borderline calls worth their attention).
+
+### Step 5: Get approval
+Explicitly ask the user to approve the recommendations or override any before proceeding to Phase 2. Do not close or merge anything until they confirm. The user reviews the decisions in the HTML report.
 
 ## Phase 2: Actuation
 
@@ -95,7 +106,7 @@ Summarize what was done: how many merged, how many closed, any issues encountere
 - **Always present findings before acting.** Never close or merge without user approval.
 - **Be strict.** A project with 0-2 GitHub stars and no npm downloads is too early-stage, regardless of how nice the README looks.
 - **Closed-source SaaS** products without a public repo or detailed integration docs should generally be rejected.
-- **Projects not using Playwright** (e.g., using CDP directly) do not belong on this list.
-- **Stealth/anti-detection** tools or forks are an automatic reject.
+- **Projects not using Playwright** (e.g., a competing engine or Playwright *alternative*) do not belong on this list — the tool must be built *on* Playwright.
+- **Scraping, non-testing automation, and anti-detection/stealth** tools built on Playwright are in scope — file them under the **Scraping & Automation** section, not Utils. (Still reject ticket scalping, doubtful-ToS government-portal automation, and closed-source SaaS where the value is a paid hosted service.)
 - **Use parallel subagents** to research PRs efficiently - batch 5-6 PRs per agent.
 - **Friendly closing comments** - always thank the submitter and explain why briefly. Invite them to resubmit if circumstances change.

--- a/.claude/skills/review-prs/references/review-criteria.md
+++ b/.claude/skills/review-prs/references/review-criteria.md
@@ -5,11 +5,13 @@
 Accept if it's clearly one of:
 - Playwright-first tool/library/integration (not "works with everything")
 - Widely useful to Playwright users (testing, tooling, ecosystem)
+- Scraping / non-testing browser automation tool built **on** Playwright (goes in the Scraping & Automation section, not Utils)
 - Guide/resource that is Playwright-specific and high quality
 - Showcase that's notable and broadly credible
 
 Reject / be skeptical if it's:
-- Generic automation/scraping infra, "AI agent platforms," or cross-framework directories
+- A Playwright *alternative* / competing automation engine (must be built on Playwright, not a replacement for it)
+- "AI agent platforms" or cross-framework directories with no Playwright-first angle
 - A niche script for a single site or personal automation project
 - Mostly marketing for a SaaS product without a clear Playwright integration
 
@@ -44,12 +46,13 @@ Descriptions should be short and factual.
 
 ## 5) Ethics / ToS / "anti-bot" red flags
 
-Auto-reject or heavily scrutinize anything centered on:
-- CAPTCHA solving/bypassing, stealth mode, anti-detection, ticket scalping
-- Automating government portals or services where ToS compliance is doubtful
-- Anything that reads like "bypass restrictions"
+Scraping, crawling, anti-detection, and stealth automation are **in scope** as long as the tool is built on Playwright — these belong in the Scraping & Automation section. CAPTCHA-bypass / anti-detection tooling (e.g. stealth-patched browsers) is acceptable when it's open source and Playwright-based.
 
-If it's even borderline, keep it out of the list.
+Still reject or heavily scrutinize:
+- Tools centered on ticket scalping or automating government portals/services where ToS compliance is doubtful
+- Closed-source SaaS where the value is a paid hosted service (proxies, paid captcha solving, etc.) rather than a Playwright tool — judge these on the closed-SaaS rule (#6), not the scraping angle
+
+When ToS/ethics are genuinely doubtful (not just "it scrapes"), keep it out.
 
 ## 6) Licensing & accessibility
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Integrations](#integrations)
 - [Language Support](#language-support)
 - [Utils](#utils)
+- [Scraping & Automation](#scraping--automation)
 - [Reporters](#reporters)
 - [Showcases](#showcases)
 - [Guides](#guides)
@@ -71,6 +72,11 @@
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.
+
+## Scraping & Automation
+
+- [Human Browser](https://humanbrowser.cloud) - Playwright drop-in that runs scripts on managed cloud browsers with residential IPs and device fingerprints, with an A2A + MCP endpoint.
+- [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - Drop-in Playwright replacement using a patched Firefox with source-level fingerprint and anti-detection patches.
 
 ## Reporters
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Language Support](#language-support)
 - [Utils](#utils)
 - [Scraping & Automation](#scraping--automation)
+- [AI & Agents](#ai--agents)
 - [Reporters](#reporters)
 - [Showcases](#showcases)
 - [Guides](#guides)
@@ -75,8 +76,15 @@
 
 ## Scraping & Automation
 
+- [camofox-browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser server usable as a Playwright-compatible automation backend, with anti-detection built in.
+- [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) - Stealth Chromium with source-level fingerprint patches and a Playwright-compatible wrapper for Python and JavaScript.
 - [Human Browser](https://humanbrowser.cloud) - Playwright drop-in that runs scripts on managed cloud browsers with residential IPs and device fingerprints, with an A2A + MCP endpoint.
 - [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - Drop-in Playwright replacement using a patched Firefox with source-level fingerprint and anti-detection patches.
+
+## AI & Agents
+
+- [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) - Official command-line interface for browser automation designed for coding agents, with token-efficient commands and installable skills.
+- [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Official Model Context Protocol server that gives LLMs browser automation via Playwright accessibility snapshots.
 
 ## Reporters
 


### PR DESCRIPTION
## What

Adds two new sections to the list and seeds them with curated, in-scope entries.

### New section: Scraping & Automation
Non-testing browser automation, scraping, and anti-detection/stealth tooling **built on Playwright**.

- [camofox-browser](https://github.com/jo-inc/camofox-browser) — stealth headless browser usable as a Playwright-compatible backend (MIT).
- [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) — stealth Chromium with a Playwright-compatible wrapper (wrapper MIT; browser binary closed).
- [Human Browser](https://humanbrowser.cloud) — Playwright drop-in running on managed cloud browsers with residential IPs.
- [invisible_playwright](https://github.com/feder-cr/invisible_playwright) — drop-in Playwright replacement using a patched Firefox with anti-detection patches (MIT, ~1k★).

### New section: AI & Agents
Official Microsoft Playwright AI tooling.

- [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) — official browser-automation CLI for coding agents.
- [Playwright MCP](https://github.com/microsoft/playwright-mcp) — official MCP server (Apache-2.0, 33k★).

This supersedes the individual submission PRs #143, #138 (dup), and #134, and resurfaces previously-closed #125 (camofox-browser) and #111 (CloakBrowser) under the updated policy.

## Policy change

Scraping, non-testing browser automation, and anti-detection/stealth tools **built on Playwright** are now in scope (filed under Scraping & Automation rather than auto-rejected). Playwright *alternatives* / competing engines and closed-source SaaS remain out. The `review-prs` skill criteria (`references/review-criteria.md`, `SKILL.md`) are updated to match, and the review report is now generated as a self-contained HTML file.

Descriptions were neutralized from the original marketing-flavored submissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)