### PR TITLE
Add browsers-benchmark and playwright-captcha to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@
 
 ## Scraping & Automation
 
+- [browsers-benchmark](https://github.com/techinz/browsers-benchmark) - Benchmark tool for testing browser automation engines against bot detection systems (Cloudflare, DataDome, reCAPTCHA, Akamai, PerimeterX, Kasada, ...).
 - [camofox-browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser server usable as a Playwright-compatible automation backend, with anti-detection built in.
 - [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) - Stealth Chromium with source-level fingerprint patches and a Playwright-compatible wrapper for Python and JavaScript.
 - [Human Browser](https://humanbrowser.cloud) - Playwright drop-in that runs scripts on managed cloud browsers with residential IPs and device fingerprints, with an A2A + MCP endpoint.
 - [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - Drop-in Playwright replacement using a patched Firefox with source-level fingerprint and anti-detection patches.
+- [playwright-captcha](https://github.com/techinz/playwright-captcha) - Automated captcha solving for Playwright, Patchright and Camoufox. Supports Cloudflare Turnstile, reCAPTCHA V2 & V3.
 
 ## AI & Agents
 


### PR DESCRIPTION
- [browsers-benchmark](https://github.com/techinz/browsers-benchmark) - benchmark tool for testing browser automation engines against bot detection systems
- [playwright-captcha](https://github.com/techinz/playwright-captcha) - automated captcha solving for Playwright, Patchright and Camoufox