### PR TITLE
Add Yorker under Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [playwright-graphql](https://www.npmjs.com/package/playwright-graphql?activeTab=readme) - Generates a type‑safe GraphQL client and fixtures for Playwright API tests, with a CLI for schema/operation generation and optional coverage reporting.
 - [playwright-pytest](https://github.com/microsoft/playwright-pytest/) - Official Pytest plugin for using Playwright pages with fixtures.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
+- [Yorker](https://yorkermonitoring.com) - Hosted Playwright execution for synthetic monitoring. Runs your browser checks across regions and exports each run as OpenTelemetry traces and metrics.
 
 ## Language Support
 


### PR DESCRIPTION
Adds Yorker to the Integrations section. Yorker provides hosted Playwright execution for synthetic monitoring: it runs your browser checks across regions and exports each run as OpenTelemetry traces and metrics. Entry placed alphabetically.