### PR TITLE
Add tracelane to Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 - [TestDino](https://testdino.com) - An AI Cloud platform for Playwright test analytics with instant failure debugging, flaky test detection, and ML categorization.
 - [testomatio-reporter](https://github.com/testomatio/reporter) - Runs and sends test executions to the TCMS testomatio, Jira / Linear / Azure DevOps task management.
 - [playwright-timeline-reporter](https://github.com/vitalets/playwright-timeline-reporter) - An interactive timeline reporter to optimize your test run performance and worker utilization.
+- [tracelane](https://github.com/Cubenest/rrweb-stack) - Captures failed Playwright tests as self-contained, offline-replayable HTML reports via rrweb, with console and failed-network panels. No backend.
 
 ## Showcases
 


### PR DESCRIPTION
Adds [tracelane](https://github.com/Cubenest/rrweb-stack), an open-source Playwright reporter that ships a single self-contained, offline HTML replay (rrweb capture + console + failed-network) on test failure — local-first, no SaaS, no backend. The artifact is one `.html` file you can attach to a CI run or a bug report and open anywhere.

- Apache-2.0
- npm: `@tracelane/playwright`
- Docs / live demo report: https://tracelane.cubenest.in

Added to `## Reporters` at the end of the section, matching the existing `- [name](url) - Description.` format.
