### PR TITLE
Add @tracelane/playwright to Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [qase](https://github.com/qase-tms/qase-javascript/tree/main/qase-playwright) - Playwright Qase Reporter, send test executions to [qase](https://qase.io).
 - [TestDino](https://testdino.com) - An AI Cloud platform for Playwright test analytics with instant failure debugging, flaky test detection, and ML categorization.
 - [testomatio-reporter](https://github.com/testomatio/reporter) - Runs and sends test executions to the TCMS testomatio, Jira / Linear / Azure DevOps task management.
+- [@tracelane/playwright](https://github.com/Cubenest/rrweb-stack/tree/main/packages/tracelane-playwright) - On test failure, writes a self-contained HTML report you can double-click and open offline (no server): an rrweb DOM session replay plus the console and failed-network panels, all inlined into the single file.
 - [playwright-timeline-reporter](https://github.com/vitalets/playwright-timeline-reporter) - An interactive timeline reporter to optimize your test run performance and worker utilization.
 
 ## Showcases


### PR DESCRIPTION
Adds `@tracelane/playwright` to the Reporters section (placed alphabetically near the other `t` entries).

It's a Playwright reporter + auto-fixture that, on a failing test, writes a single self-contained HTML file you can double-click and open offline — no local server, no unzip. The one file contains an rrweb DOM session replay of the run alongside the console output and failed-network responses, all inlined.

- npm: https://www.npmjs.com/package/@tracelane/playwright
- Source: https://github.com/Cubenest/rrweb-stack/tree/main/packages/tracelane-playwright
- Docs + live demo report: https://tracelane.cubenest.in/demo
- License: Apache-2.0

It also ships a WebdriverIO variant (`@tracelane/wdio`). It's pre-1.0 (alpha), solo-maintained and unfunded — no SaaS, no telemetry, no cloud upload; reports stay local. Happy to adjust the wording or placement to fit the list's conventions.