### PR TITLE
Add Browser-CLI to AI & Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 
 - [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) - Official command-line interface for browser automation designed for coding agents, with token-efficient commands and installable skills.
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Official Model Context Protocol server that gives LLMs browser automation via Playwright accessibility snapshots.
+- [Browser-CLI](https://github.com/zmysysz/browser-cli) - CLI browser automation tool for AI agents with stealth mode, state persistence, and CDP support.
 
 ## Reporters
 


### PR DESCRIPTION
## Add Browser-CLI

Browser-CLI is a CLI browser automation tool for AI agents, powered by Playwright.

### Features
- CLI-first design for AI agents and automation scripts
- Built-in stealth mode to bypass browser automation detection
- State persistence (save/restore login sessions)
- CDP connection to external browsers

Added to the AI & Agents section alongside Playwright Agent CLI and Playwright MCP.