### PR TITLE
Add google-doc-claude to Scraping & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 - [browsers-benchmark](https://github.com/techinz/browsers-benchmark) - Benchmark tool for testing browser automation engines against bot detection systems (Cloudflare, DataDome, reCAPTCHA, Akamai, PerimeterX, Kasada, ...).
 - [camofox-browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser server usable as a Playwright-compatible automation backend, with anti-detection built in.
 - [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) - Stealth Chromium with source-level fingerprint patches and a Playwright-compatible wrapper for Python and JavaScript.
+- [google-doc-claude](https://github.com/anaypaul/google-doc-claude) - Playwright automation that adds true inline (anchored) comments to Google Docs — comments no public Google API can create — exposed to Claude Code as an MCP server and CLI.
 - [Human Browser](https://humanbrowser.cloud) - Playwright drop-in that runs scripts on managed cloud browsers with residential IPs and device fingerprints, with an A2A + MCP endpoint.
 - [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - Drop-in Playwright replacement using a patched Firefox with source-level fingerprint and anti-detection patches.
 - [playwright-captcha](https://github.com/techinz/playwright-captcha) - Automated captcha solving for Playwright, Patchright and Camoufox. Supports Cloudflare Turnstile, reCAPTCHA V2 & V3.


### PR DESCRIPTION
Adds [google-doc-claude](https://github.com/anaypaul/google-doc-claude) to the Scraping & Automation section, alphabetically between `CloakBrowser` and `Human Browser`.

It's a real-world Playwright automation app (MIT, Python): it drives the live Google Docs UI to add **true inline/anchored comments** — comments no public Google API can create — and exposes that to Claude Code as an MCP server + CLI.