### PR TITLE
Add Lastest to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [cucumber-playwright](https://github.com/Tallyb/cucumber-playwright) - A starter repo for writing E2E tests based on Cucumber with Playwright using TypeScript.
 - [@guidepup/Playwright](https://github.com/guidepup/guidepup-playwright) - VoiceOver and NVDA screen reader driver integration for Playwright.
 - [Happo](https://docs.happo.io/docs/playwright) - Catch unexpected visual and accessibility changes and UI bugs.
+- [Lastest](https://lastest.cloud) - Visual regression testing for Playwright: screenshot diffing, AI-assisted baseline review, and flake triage.
 - [Playwright Angular Schematic](https://github.com/playwright-community/playwright-ng-schematics) - Adds Playwright Test to your Angular project.
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD testing with Playwright runner and CucumberJS.
 - [Playwright CRX](https://github.com/ruifigueira/playwright-crx) - Playwright codegen as a chrome extension. Available in [Chrome Web Store](https://chromewebstore.google.com/detail/playwright-crx/jambeljnbnfbkcpnoiaedcabbgmnnlcd).


### PR DESCRIPTION
Lastest (lastest.cloud) is a Playwright-native visual regression testing platform with screenshot diffing, AI-assisted baseline review, and flake triage. It fits naturally in the Integrations section alongside Happo.