### PR TITLE
Add Testward to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [playwright-graphql](https://www.npmjs.com/package/playwright-graphql?activeTab=readme) - Generates a type‑safe GraphQL client and fixtures for Playwright API tests, with a CLI for schema/operation generation and optional coverage reporting.
 - [playwright-pytest](https://github.com/microsoft/playwright-pytest/) - Official Pytest plugin for using Playwright pages with fixtures.
 - [Serenity/JS](https://serenity-js.org) - Acceptance testing, reporting, and test integration framework for Playwright, implementing the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern/).
+- [Testward](https://testward.app) - GitHub App that flags which Playwright specs a pull request will break — at review time, even when the specs live in a separate repo.
 
 ## Language Support
 


### PR DESCRIPTION
Adding [Testward](https://testward.app) — a GitHub App that reads each pull request in an app repo and flags which Playwright specs the change will break, at review time. It extracts the anchors the diff touches (data-testid, getByRole/getByText targets, aria-labels, routes) and matches them against spec files — including when the Playwright suite lives in a separate repo linked via a one-line config.

Disclosure: I'm the author. Free on public repos. Placed alphabetically at the end of Integrations. A no-install, client-side demo of the diff analysis is at https://testward.app/diff-scanner.