### PR TITLE
Add PR Preview to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - [playwright-ui5](https://github.com/detachhead/playwright-ui5) - Custom selector engine for sapui5.
 - [playwright-xpath](https://github.com/detachhead/playwright-xpath) - Custom selector engine for xpath 2 and 3.
 - [POMWright](https://github.com/DyHex/POMWright) - TypeScript-based Page Object Model framework with automatic nested/chained locator generation.
+- [PR Preview](https://www.pr-preview.com/) - Playwright-powered MCP for Claude Code that drives your app in a headed browser and records before/after demo videos of a pull request as MP4 or GIF.
 - [selenosis](https://github.com/alcounit/selenosis) - Stateless Kubernetes-native hub that routes Selenium, Playwright, and MCP sessions to on-demand browser pods via custom resources.
 - [TestingBot](https://testingbot.com) - Connect your Playwright tests with browsers in the Cloud.
 - [Try Playwright](https://try.playwright.tech) - Interactive playground for running Playwright tests.


### PR DESCRIPTION
Adds **PR Preview** to the **Utils** section.

PR Preview is a Playwright-powered MCP for Claude Code (also an open-source CLI) that drives your app in a headed browser, records the journey, and produces polished before/after demo videos of a pull request as MP4 or GIF — a handy way to generate visual PR artifacts from Playwright-driven browser sessions.

- One suggestion in this PR.
- Entry is placed alphabetically in Utils and the description ends with a full stop.
- Not a duplicate of an existing entry.