### PR TITLE
Add Tessera to Showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 
 - [Elastic APM JS agent](https://github.com/elastic/apm-agent-rum-js) - Playwright is used to run benchmark tests across browsers.
 - [playwright-examples](https://github.com/microsoft/playwright-examples) - Various testing scenarios with Playwright.
+- [Tessera](https://app.tesserae.site) - Playwright powers the live device viewports, streaming CDP screencast frames of many real browser sessions to a canvas at once.
 - [TypeScript](https://github.com/microsoft/TypeScript) - Playwright is used to test TypeScript.js across browsers.
 - [VS Code](https://github.com/microsoft/vscode) - Playwright is used to run cross-browser tests on their web builds.
 - [xterm.js](https://github.com/xtermjs/xterm.js) - Playwright is used to run cross-browser integration tests.


### PR DESCRIPTION
Adding [Tessera ](https://app.tesserae.site/)to Showcases.

It's a responsive testing canvas where every device tile is a Playwright browser context. The server runs one shared browser, gives each tile its own context at exact device dimensions and DPR, and streams CDP screencast frames over a websocket as binary JPEGs. Input events go back up the same socket into Input.dispatchMouseEvent and friends. Offscreen tiles stop their screencast so a big canvas stays cheap.

Kept alphabetical order in the section.