### PR TITLE
Add Browserless to Scraping & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [Human Browser](https://humanbrowser.cloud) - Playwright drop-in that runs scripts on managed cloud browsers with residential IPs and device fingerprints, with an A2A + MCP endpoint.
 - [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - Drop-in Playwright replacement using a patched Firefox with source-level fingerprint and anti-detection patches.
 - [playwright-captcha](https://github.com/techinz/playwright-captcha) - Automated captcha solving for Playwright, Patchright and Camoufox. Supports Cloudflare Turnstile, reCAPTCHA V2 & V3.
+- [Browserless](https://github.com/browserless/browserless) - Connects Playwright to remote managed browsers over WebSocket, with stealth and CAPTCHA handling.
 
 ## AI & Agents
 


### PR DESCRIPTION
Adds **Browserless** to the *Scraping & Automation* section, alongside the other Playwright-compatible remote/cloud backends (Human Browser, camofox-browser).

Browserless lets you connect Playwright to remote managed browsers over WebSocket, with stealth and CAPTCHA handling. Canonical open-source repo: https://github.com/browserless/browserless

It's an actively maintained, established project (well over six months old). Single-line entry appended to the end of the list in the existing format.