### PR TITLE
Add five46

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 
 ## AI & Agents
 
+- [five46](https://github.com/sekharsdet/five46) - BYOK CLI that drives a real browser (or real HTTP requests) toward a plain-English goal using your own LLM key, entirely locally, and writes the result as a real, standalone Playwright spec (or `node:test` script).
 - [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) - Official command-line interface for browser automation designed for coding agents, with token-efficient commands and installable skills.
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Official Model Context Protocol server that gives LLMs browser automation via Playwright accessibility snapshots.
 


### PR DESCRIPTION
Adding [five46](https://github.com/sekharsdet/five46) to the AI & Agents section.

five46 is a BYOK CLI that drives a real Playwright browser (or real HTTP requests, for API testing) toward a plain-English goal using your own LLM key (OpenAI/Anthropic/Gemini/Groq/Bedrock), entirely locally with no cloud sandbox. On success it writes the run as a real, standalone `.spec.ts` file re-runnable with plain `npx playwright test` — no five46/LLM involved in ever running it again.