### PR TITLE
Add QAIA to AI &amp; Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 
 - [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) - Official command-line interface for browser automation designed for coding agents, with token-efficient commands and installable skills.
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Official Model Context Protocol server that gives LLMs browser automation via Playwright accessibility snapshots.
+- [QAIA](https://github.com/QAIA-Project/QAIA) - Claude Code plugins that turn a user story into a traceable Gherkin test book, then into native Playwright tests using Page Object Model as fixtures.
 
 ## Reporters
 


### PR DESCRIPTION
One entry, in `AI & Agents`, after the two existing lines (alphabetical).

[QAIA](https://github.com/QAIA-Project/QAIA) is a set of Claude Code plugins (MIT) that take a user story to a Gherkin test book with stable scenario IDs and a requirement coverage matrix, then to **native Playwright tests** using Page Object Model as fixtures. No API key, no MCP server, no hooks — Markdown skills invoked inside the user's own session.

Playwright-relevant specifics, since that is what this list is about:

- Generated suites use POM-as-fixtures and `getByRole`/`getByTestId` locators; a static checker in the repo flags raw CSS/XPath selectors and forbidden fixed waits.
- A generated suite runs on a GitHub Actions runner with **no Claude session and no skill loaded** — [8 tests, 8 green](https://github.com/QAIA-Project/QAIA/actions/runs/30702503888). The tests are ordinary Playwright once produced.
- Sibling skills cover `@axe-core/playwright` accessibility, visual snapshots with a stated tolerance, and passive security checks — all through the Playwright runner rather than a second driver stack.

**Honest state, up front:** pre-alpha. No human pilot has run it end to end, and the project publishes its own unfavourable evaluations (a 13-persona review scored it 2.4/5 — self-administered agent panels, not outside reviewers, and it says so). Entirely reasonable to decline on maturity grounds; I would rather say this than have it found later.

Guidelines checked: single suggestion, single PR, description short and ending with a period, searched the list for duplicates first, spelling and trailing whitespace checked.
