### PR TITLE
Add AntiBrow to Scraping & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 
 ## Scraping & Automation
 
+- [AntiBrow](https://github.com/antibrow/antibrow) - Patched Chromium that returns a standard Playwright BrowserContext over CDP, with fingerprints applied in the C++ layer instead of injected scripts. MIT SDKs for Python and JavaScript, plus an MCP server mode.
 - [Browserless](https://github.com/browserless/browserless) - Connects Playwright to remote managed browsers over WebSocket, with stealth and CAPTCHA handling.
 - [browsers-benchmark](https://github.com/techinz/browsers-benchmark) - Benchmark tool for testing browser automation engines against bot detection systems (Cloudflare, DataDome, reCAPTCHA, Akamai, PerimeterX, Kasada, ...).
 - [camofox-browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser server usable as a Playwright-compatible automation backend, with anti-detection built in.


### PR DESCRIPTION
Adds **AntiBrow** to the *Scraping & Automation* section, in alphabetical order at the top of the list (before Browserless).

**What it is**

A patched Chromium build driven through the standard Playwright API. Fingerprint values are produced inside Chromium's C++ layer rather than injected as page scripts, so there is no separate API to learn — `launch()` hands back a normal Playwright `BrowserContext` and `Page` over CDP.

**Install**

```bash
pip install antibrow
```

```bash
npm install anti-detect-browser playwright-core
```

**Interface difference vs. plain Playwright**

Only the launch line changes; everything after it is standard Playwright:

```python
from antibrow import launch

browser = launch()
page = browser.new_page()
page.goto("https://example.com")
```

There is also an MCP server mode (`npx anti-detect-browser --mcp`) for agent clients.

**Playwright/CDP compatibility, if useful for verification**

- `anti-detect-browser` declares `playwright-core` as a peer dependency (`>=1.40.0`): https://github.com/antibrow/antibrow/blob/main/js/package.json
- `antibrow` on PyPI depends on `playwright>=1.40`: https://github.com/antibrow/antibrow/blob/main/python/pyproject.toml
- The JS SDK's `launch()` resolves to `{ browser, context, page, profileDir }`, where `context` and `page` are the Playwright objects: https://github.com/antibrow/antibrow/blob/main/js/README.md

**Licensing and hosting**

It runs locally; there is no hosted endpoint to connect to. The SDKs in the repository are MIT, and the browser binary is closed-source and downloaded on first run onto the user's own machine — the same split as CloakBrowser, which is already on the list. Happy to reword the entry or withdraw it if that split isn't a fit for the list.
