### PR TITLE
Add Webcmd to AI & Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 
 - [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) - Official command-line interface for browser automation designed for coding agents, with token-efficient commands and installable skills.
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Official Model Context Protocol server that gives LLMs browser automation via Playwright accessibility snapshots.
+- [Webcmd](https://github.com/agentrhq/webcmd) - CLI built on Playwright that learns a site's navigation once and compiles it into deterministic per-site commands for coding agents.
 
 ## Reporters
 


### PR DESCRIPTION
Adds Webcmd to the AI & Agents section.

Webcmd is built on playwright-core. It drives a browser to learn how a site
is navigated, then compiles that into deterministic per-site CLI commands
that agents reuse without re-exploring the site. Apache-2.0.

Disclosure: I contribute to this project.