### PR TITLE
Add page-shot to AI & Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 
 - [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) - Official command-line interface for browser automation designed for coding agents, with token-efficient commands and installable skills.
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Official Model Context Protocol server that gives LLMs browser automation via Playwright accessibility snapshots.
+- [page-shot](https://github.com/painfulChen/page-shot) - Dual-viewport screenshots and visual QA built for AI coding agents: heuristic design audit plus side-by-side prototype-vs-implementation diffing.
 
 ## Reporters
 


### PR DESCRIPTION
[page-shot](https://github.com/painfulChen/page-shot) is a pair of CLI tools built on Playwright, designed for AI coding agents (Claude Code, Codex, Cursor) doing frontend work:

- **page-shot** — one command for full-page screenshots at mobile (393px) + desktop (1440px), with a heuristic visual-quality audit (radius-tier sprawl, sub-10px text, undersized tap targets, nested cards). Output paths are printed for agents to read back.
- **proto-diff** — screenshots a design prototype and the live implementation at both viewports and stitches side-by-side comparison images with a rough pixel-diff ratio, so agents can iterate on visual fidelity.

Uses the system Chrome channel (no browser download needed). MIT licensed.