### PR TITLE
Add termux-playwright to Scraping & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 - [Human Browser](https://humanbrowser.cloud) - Playwright drop-in that runs scripts on managed cloud browsers with residential IPs and device fingerprints, with an A2A + MCP endpoint.
 - [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - Drop-in Playwright replacement using a patched Firefox with source-level fingerprint and anti-detection patches.
 - [playwright-captcha](https://github.com/techinz/playwright-captcha) - Automated captcha solving for Playwright, Patchright and Camoufox. Supports Cloudflare Turnstile, reCAPTCHA V2 & V3.
+- [termux-playwright](https://github.com/uno-km/termux-playwright-demo) - Production-grade Playwright & Chromium browser automation and stealth crawler toolkit for Android Termux.
 
 ## AI & Agents
 


### PR DESCRIPTION
### Summary
Adds [termux-playwright](https://github.com/uno-km/termux-playwright-demo) to the **Scraping & Automation** section.

### What is termux-playwright?
A production-grade Python package that orchestrates native Chromium browser automation on Android Termux (ARM64/x86_64) with zero-root, persistent process lifecycle management, and stealth anti-bot evasion.

- **GitHub:** https://github.com/uno-km/termux-playwright-demo
- **PyPI:** https://pypi.org/project/termux-playwright/
- **License:** MIT