### PR TITLE
Add CapMonster Cloud to Scraping & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - [Browserless](https://github.com/browserless/browserless) - Connects Playwright to remote managed browsers over WebSocket, with stealth and CAPTCHA handling.
 - [browsers-benchmark](https://github.com/techinz/browsers-benchmark) - Benchmark tool for testing browser automation engines against bot detection systems (Cloudflare, DataDome, reCAPTCHA, Akamai, PerimeterX, Kasada, ...).
 - [camofox-browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser server usable as a Playwright-compatible automation backend, with anti-detection built in.
+- [CapMonster Cloud](https://github.com/CapMonsterCloud/capmonster-captcha-solver-docs) - Cloud-based CAPTCHA solving API and SDK integrations for automated Playwright browsers.
 - [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) - Stealth Chromium with source-level fingerprint patches and a Playwright-compatible wrapper for Python and JavaScript.
 - [Figranium](https://github.com/figranium/figranium) - Build complex browser workflows visually and execute them via API. Dockerized and Playwright-based.
 - [Human Browser](https://humanbrowser.cloud) - Playwright drop-in that runs scripts on managed cloud browsers with residential IPs and device fingerprints, with an A2A + MCP endpoint.


### PR DESCRIPTION
### Summary
Add CapMonster Cloud to the `Scraping & Automation` section.

### Details
- **Description:** Cloud-based CAPTCHA solving API and SDK integrations for automated Playwright browsers.
- **Repository:** https://github.com/CapMonsterCloud/capmonster-captcha-solver-docs (MIT License).
- **Placement:** Inserted alphabetically into the `Scraping & Automation` category (between `camofox-browser` and `CloakBrowser`).
- **Playwright Relevance:** Provides ready-to-use code snippets and open-source SDK integrations for solving reCAPTCHA, hCaptcha, and Cloudflare Turnstile directly within Playwright (Python and Node.js) automation pipelines.