### PR TITLE
Add Qualflare to Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [playwright-tesults-reporter](https://github.com/tesults/playwright-tesults-reporter) - A library for uploading test results to Tesults from Playwright.
 - [playwright-xray](https://github.com/inluxc/playwright-xray) - Playwright Xray Reporter, send test executions to Jira / Xray.
 - [qase](https://github.com/qase-tms/qase-javascript/tree/main/qase-playwright) - Playwright Qase Reporter, send test executions to [qase](https://qase.io).
+- [Qualflare](https://qualflare.com/playwright-test-reporting/) - Uploads Playwright results to Qualflare for history-based flaky test detection, failure clustering, and release-risk scoring.
 - [TestDino](https://testdino.com) - An AI Cloud platform for Playwright test analytics with instant failure debugging, flaky test detection, and ML categorization.
 - [testomatio-reporter](https://github.com/testomatio/reporter) - Runs and sends test executions to the TCMS testomatio, Jira / Linear / Azure DevOps task management.
 - [playwright-timeline-reporter](https://github.com/vitalets/playwright-timeline-reporter) - An interactive timeline reporter to optimize your test run performance and worker utilization.


### PR DESCRIPTION
Adds [Qualflare](https://github.com/Qualflare/qualflare-playwright) to **Reporters**.

[`@qualflare/playwright`](https://www.npmjs.com/package/@qualflare/playwright) is an open-source (Apache-2.0) Playwright reporter that uploads results to Qualflare, which uses run history for flaky-test detection, failure clustering, and release-risk scoring. Same category as the existing Checkly and currents-dev entries.

**Disclosure:** Qualflare is my SaaS; the reporter itself is open source.

`npx awesome-lint README.md` reports no new issues against this change.
